### PR TITLE
Allow construction with a mongist connection

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -119,6 +119,11 @@ module.exports = class Database extends EventEmitter {
           resolve(connection);
         });
       });
+    } else if (this.connectionString instanceof Database) { // mongoist
+      return this.connectionString.connect().then((connection) => {
+        this.connection = connection;
+        return connection;
+      });
     }
   }
 

--- a/test/database.js
+++ b/test/database.js
@@ -198,10 +198,19 @@ describe('database', function() {
     expect(docs).to.have.length(4);
   });
 
+  it('should allow passing in a mongoist connection', async() => {
+    const mongoistDb = mongoist(connectionString);
+    const db = mongoist(mongoistDb);
+
+    const docs = await db.a.find({});
+
+    expect(docs).to.have.length(4);
+  });
+
   it('should drop a database passing in a mongojs connection', async() => {
     const dbConnectionString = 'mongodb://localhost/test2';
     const db = mongoist(dbConnectionString);
-    
+
     await db.b.insert({ name: 'Squirtle',type: 'water', level: 10, });
     const docs = await db.b.find({});
     expect(docs).to.have.length(1);


### PR DESCRIPTION
Currently, when calling `mongoist()` with an existing mongoist
connection, the database fails to initialize properly resulting in
undefined errors when calling database or collection methods.

I added an affordance for checking if the `connectionString` is an
instance of `Database` which means we can call the connect function
on that database to initialize this mongoist instance.