### PR TITLE
Fix writeOpts

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -54,9 +54,7 @@ module.exports = class Collection {
       .then(result => result.values);
   }
 
-  insert(docOrDocs, options) {
-    options = options || writeOpts;
-
+  insert(docOrDocs, opts) {
     const docs = Array.isArray(docOrDocs) ? docOrDocs : [docOrDocs];
 
     for (let i = 0; i < docs.length; i++) {
@@ -65,7 +63,7 @@ module.exports = class Collection {
 
     return this
       .connect()
-      .then(connection => connection.insert(docs, options))
+      .then(connection => connection.insert(docs, Object.assign({}, writeOpts, opts)))
       .then(() => docOrDocs);
   }
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -303,4 +303,21 @@ describe('collection', function() {
     expect(types).to.deep.include({ foo: 'fire' });
     expect(types).to.deep.include({ foo: 'water' });
   });
+
+  it('should not mutate write options', async () => {
+    const mockDb = mongoist(connectionString);
+    mockDb.connection = {
+      collection: async () => {
+        return {
+          insert: async (docs, options) => {
+            expect(options).to.deep.equal({ writeConcern: { w: 1 }, ordered: true });
+            options.foo = 'bar';
+          }
+        };
+      }
+    }
+    await mockDb.b.insert({ foo: 'bar' });
+    await mockDb.b.insert({ foo: 'baz' });
+  });
+
 });


### PR DESCRIPTION
Some versions of mongodb mutate the options value provided to the insert
call, and previously a reference to the global `writeOpts` constant was
passed into insert calls which could then be mutated and for other
calls. This updates the collection class to always copy the values, not
pass the object in directly.