### PR TITLE
Add and test for close event on Cursor

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -119,6 +119,8 @@ module.exports = class Cursor extends Readable {
           cursor = cursor[key](this._options[key]);
         });
 
+        cursor.on('close', (...args) => this.emit('close', ...args));
+
         this.cursor = cursor;
 
         return cursor;

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -229,7 +229,15 @@ describe('cursor', function() {
           resolve();
         });
     });
-  })
+  });
+
+  it('should emit a close event when closed', async () => {
+    const cursor = db.a.findAsCursor();
+    return new Promise((resolve) => {
+      cursor.once('close', resolve);
+      cursor.close();
+    });
+  });
 });
 
 


### PR DESCRIPTION
Despite (some) documentation [to the contrary](https://nodejs.org/api/stream.html#stream_event_close_1), some code [assumes](https://github.com/pull-stream/stream-to-pull-stream/blob/master/index.js#L175-L178) that destroying a stream will emit a close event. This Cursor does not emit a close event, which causes some [interoperability issues](https://github.com/pull-stream/stream-to-pull-stream/issues/12). Streams should [probably](https://nodejs.org/api/stream.html#stream_readable_destroy_error) emit the close event despite not being required to do so by the streams2 spec.