### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -68,16 +68,29 @@ module.exports = class Collection {
   }
 
   insert(docOrDocs, opts) {
-    const docs = Array.isArray(docOrDocs) ? docOrDocs : [docOrDocs];
+    return Array.isArray(docOrDocs)
+      ? this.insertMany(docOrDocs, opts)
+      : this.insertOne(docOrDocs, opts);
+  }
 
+  insertOne(doc, opts) {
+    if (!doc._id) doc._id = oid();
+
+    return this
+      .connect()
+      .then(connection => connection.insertOne(doc, Object.assign({}, writeOpts, opts)))
+      .then(() => doc);
+  }
+
+  insertMany(docs, opts) {
     for (let i = 0; i < docs.length; i++) {
       if (!docs[i]._id) docs[i]._id = oid();
     }
 
     return this
       .connect()
-      .then(connection => connection.insert(docs, Object.assign({}, writeOpts, opts)))
-      .then(() => docOrDocs);
+      .then(connection => connection.insertMany(docs, Object.assign({}, writeOpts, opts)))
+      .then(() => docs);
   }
 
   update(query, update, opts) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -95,10 +95,16 @@ module.exports = class Collection {
 
   update(query, update, opts) {
     opts = opts || {};
+    const isMulti = opts.multi
 
     return this
       .connect()
-      .then(connection => connection.update(query, update, Object.assign({}, writeOpts, opts)))
+      .then(connection => {
+        const updateFn = isMulti
+          ? connection.updateMany.bind(connection)
+          : connection.updateOne.bind(connection)
+        return updateFn(query, update, Object.assign({}, writeOpts, opts))
+      })
       .then((result) => result.result);
   }
 
@@ -107,7 +113,7 @@ module.exports = class Collection {
 
     if (doc._id) {
       return this
-        .update({ _id: doc._id }, doc, Object.assign({ upsert: true }, opts))
+        .update({ _id: doc._id }, { $set: doc }, Object.assign({ upsert: true }, opts))
         .then(() => doc);
     } else {
       return this.insert(doc, opts);
@@ -185,9 +191,7 @@ module.exports = class Collection {
   }
 
   ensureIndex(index, opts) {
-    opts = opts || {};
-
-    return this.connect().then(connection => connection.ensureIndex(index, opts));
+    return this.createIndex(index, opts)
   }
 
   getIndexes() {

--- a/test/collection.js
+++ b/test/collection.js
@@ -311,7 +311,7 @@ describe('collection', function() {
     mockDb.connection = {
       collection: async () => {
         return {
-          insert: async (docs, options) => {
+          insertOne: async (docs, options) => {
             expect(options).to.deep.equal({ writeConcern: { w: 1 }, ordered: true });
             options.foo = 'bar';
           }


### PR DESCRIPTION
This fixes a number of deprecation warnings from the native MongoDB driver.

`insert` -> `insertOne` and `insertMany`
`update` -> `updateOne` and `updateMany`
`ensureIndex` -> `createIndex`

The only deprecation left is the `group` function but I'm not familiar enough with the `aggregate` functions to take a stab at it :)