### PR TITLE
Adds replaceOne for collections

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -17,7 +17,8 @@ class Bulk {
     this.cmdKeys = {
       insert: 'nInserted',
       delete: 'nRemoved',
-      update: 'nUpserted'
+      update: 'nUpserted',
+      replaceOne: 'nModified'
     }
   }
 
@@ -52,10 +53,16 @@ class Bulk {
       cmd.updates.push({ q, u, multi, upsert })
     }
 
-    return new FindSyntax({ 
-      update, 
-      upsert(upsertValue) { upsert = upsertValue }, 
-      remove 
+    const replace = (u, multi) => {
+      const cmd = this.ensureCommand('replaceOne', 'replaces');
+      cmd.replaces.push({ q, u, multi })
+    }
+
+    return new FindSyntax({
+      update,
+      upsert(upsertValue) { upsert = upsertValue },
+      remove,
+      replace
     });
   }
 
@@ -110,12 +117,15 @@ class Bulk {
       nInsertOps: 0,
       nUpdateOps: 0,
       nRemoveOps: 0,
+      nModifyOps: 0,
       nBatches: this.cmds.length
     }
   
     this.cmds.forEach(function (cmd) {
       if (cmd.update) {
         obj.nUpdateOps += cmd.updates.length
+      } else if (cmd.replace) {
+        obj.nModifyOps += cmd.replaces.length
       } else if (cmd.insert) {
         obj.nInsertOps += cmd.documents.length
       } else if (cmd.delete) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -103,9 +103,17 @@ module.exports = class Collection {
         const updateFn = isMulti
           ? connection.updateMany.bind(connection)
           : connection.updateOne.bind(connection)
-        return updateFn(query, update, Object.assign({}, writeOpts, opts))
+        return updateFn(query, update, Object.assign({}, writeOpts, opts));
       })
       .then((result) => result.result);
+  }
+
+  replace(query, doc, opts) {
+    return this
+      .connect()
+      .then(connection => {
+        return connection.replaceOne(query, doc, opts);
+      })
   }
 
   save(doc, opts) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,7 +225,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1056,7 +1056,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -4869,7 +4869,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {

--- a/test/bulk.js
+++ b/test/bulk.js
@@ -50,10 +50,11 @@ describe('bulk', function() {
 
 
     expect(docs[0].name).to.equal('Charmander');
-    expect(docs[1].name).to.equal(undefined);
-
     expect(docs[0].type).to.equal('fire');
+    expect(docs[0]).not.to.have.any.keys('level');
+
     expect(docs[1].type).to.equal('fire');
+    expect(docs[1]).not.to.have.any.keys('name', 'level');
   });
 
   it('should update documents in bulk', async() => {

--- a/test/collection.js
+++ b/test/collection.js
@@ -146,6 +146,17 @@ describe('collection', function() {
     expect(idleDocsCount).equal(2);
   });
 
+  it('should replace a document', async() => {
+    const pikachu = { name: 'Pikachu' };
+    const charmander = await db.a.findOne({ name: 'Charmander' });
+
+    await db.a.replace({ _id: charmander._id }, pikachu);
+    const replacedDocument = await db.a.findOne({ _id: charmander._id });
+
+    expect(replacedDocument).to.deep.equal(Object.assign({ _id: charmander._id }, pikachu));
+    expect(replacedDocument).not.have.any.keys('type', 'level');
+  });
+
   it('should update multiple documents', async() => {
     const lastErrorObject = await db.a.update({type: 'water'}, {$set: {type: 'aqua'}}, { multi: true });
     expect(lastErrorObject.n).to.equal(3);


### PR DESCRIPTION
Since the newer `updateMany` and `updateOne` functions force you to pass [an update operator](https://docs.mongodb.com/manual/reference/operator/update/) you can no longer replace an entire document.

This PR adds this functionality back in, albeit with a different function name — `replace`.

Additionally uses the `replaceOne` function from the official Bulk driver for bulk operations.